### PR TITLE
Refactor extract class RouteParams

### DIFF
--- a/example/example.php
+++ b/example/example.php
@@ -6,13 +6,14 @@ require_once \dirname(__DIR__) . '/vendor/autoload.php';
 
 use Gacela\Router\Request;
 use Gacela\Router\Route;
+use Gacela\Router\RoutingConfigurator;
 
 # php -S localhost:8081 example/example.php
 
 $controller = new class() {
     public function __invoke(): string
     {
-        $request = Request::fromGlobals();
+        $request = Request::instance();
         $number = $request->get('number');
 
         if (!empty($number)) {
@@ -28,11 +29,13 @@ $controller = new class() {
     }
 };
 
-# localhost:8081/custom/123
-Route::get('custom/{number}', $controller, 'customAction');
+Route::configure(static function (RoutingConfigurator $routes) use ($controller): void {
+    # localhost:8081/custom/123
+    $routes->get('custom/{number}', $controller, 'customAction');
 
-# localhost:8081/custom
-Route::get('custom', $controller);
+    # localhost:8081/custom
+    $routes->get('custom', $controller);
 
-# localhost:8081?number=456
-Route::get('/', $controller);
+    # localhost:8081?number=456
+    $routes->get('/', $controller);
+});

--- a/src/Router/Request.php
+++ b/src/Router/Request.php
@@ -15,17 +15,26 @@ final class Request
     public const METHOD_POST = 'POST';
     public const METHOD_PUT = 'PUT';
     public const METHOD_TRACE = 'TRACE';
+    private static ?self $instance = null;
 
-    public function __construct(
+    private function __construct(
         private array $query,
         private array $request,
         private array $server,
     ) {
     }
 
-    public static function fromGlobals(): self
+    public static function resetCache(): void
     {
-        return new self($_GET, $_POST, $_SERVER);
+        self::$instance = null;
+    }
+
+    public static function instance(): self
+    {
+        if (self::$instance === null) {
+            self::$instance = new self($_GET, $_POST, $_SERVER);
+        }
+        return self::$instance;
     }
 
     public function isMethod(string $method): bool

--- a/src/Router/RouteParams.php
+++ b/src/Router/RouteParams.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Router;
+
+use ReflectionClass;
+use ReflectionNamedType;
+
+use function count;
+
+final class RouteParams
+{
+    private array $asArray;
+
+    public function __construct(
+        private Route $route,
+    ) {
+        $this->asArray = $this->getParams();
+    }
+
+    public function asArray(): array
+    {
+        return $this->asArray;
+    }
+
+    /**
+     * @psalm-suppress MixedAssignment,PossiblyNullReference
+     */
+    private function getParams(): array
+    {
+        $params = [];
+        $pathParamKeys = [];
+        $pathParamValues = [];
+
+        preg_match($this->route->getPathPattern(), '/' . $this->route->path(), $pathParamKeys);
+        preg_match($this->route->getPathPattern(), Request::instance()->path(), $pathParamValues);
+
+        unset($pathParamValues[0], $pathParamKeys[0]);
+        $pathParamKeys = array_map(static fn ($key) => trim($key, '{}'), $pathParamKeys);
+
+        while (count($pathParamValues) !== count($pathParamKeys)) {
+            array_shift($pathParamKeys);
+        }
+
+        $pathParams = array_combine($pathParamKeys, $pathParamValues);
+        $actionParams = (new ReflectionClass($this->route->controller()))
+            ->getMethod($this->route->action())
+            ->getParameters();
+
+        foreach ($actionParams as $actionParam) {
+            /** @var string|null $paramType */
+            $paramType = null;
+
+            if ($actionParam->getType() && is_a($actionParam->getType(), ReflectionNamedType::class)) {
+                $paramType = $actionParam->getType()->getName();
+            }
+
+            $paramName = $actionParam->getName();
+
+            $value = match ($paramType) {
+                'string' => $pathParams[$paramName] ?? '',
+                'int' => (int)($pathParams[$paramName] ?? 0),
+                'float' => (float)($pathParams[$paramName] ?? 0.0),
+                'bool' => (bool)json_decode($pathParams[$paramName] ?? '0'),
+                null => null,
+            };
+
+            $params[$paramName] = $value;
+        }
+
+        return $params;
+    }
+}

--- a/tests/Unit/Router/RouteTest.php
+++ b/tests/Unit/Router/RouteTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GacelaTest\Unit\Router;
 
+use Gacela\Router\Request;
 use Gacela\Router\Route;
 use Gacela\Router\RoutingConfigurator;
 use Generator;
@@ -15,7 +16,7 @@ final class RouteTest extends TestCase
 
     protected function tearDown(): void
     {
-        Route::resetCache();
+        Request::resetCache();
     }
 
     public function test_it_should_respond_if_everything_matches(): void


### PR DESCRIPTION
## 📚 Description

- Extract the huge `getParams()` methods from Route class on its own class
- Make the Request class a singleton (using always the constant magic globals (at least for now)