### PR TITLE
UnsupportedHttpMethodException if HTTP verb is invalid

### DIFF
--- a/src/Router/RoutingConfigurator.php
+++ b/src/Router/RoutingConfigurator.php
@@ -5,14 +5,14 @@ declare(strict_types=1);
 namespace Gacela\Router;
 
 /**
- * @method get(string $path, object|string $controller, string $action = '__invoke')
  * @method head(string $path, object|string $controller, string $action = '__invoke')
  * @method connect(string $path, object|string $controller, string $action = '__invoke')
+ * @method get(string $path, object|string $controller, string $action = '__invoke')
  * @method post(string $path, object|string $controller, string $action = '__invoke')
+ * @method put(string $path, object|string $controller, string $action = '__invoke')
+ * @method patch(string $path, object|string $controller, string $action = '__invoke')
  * @method delete(string $path, object|string $controller, string $action = '__invoke')
  * @method options(string $path, object|string $controller, string $action = '__invoke')
- * @method patch(string $path, object|string $controller, string $action = '__invoke')
- * @method put(string $path, object|string $controller, string $action = '__invoke')
  * @method trace(string $path, object|string $controller, string $action = '__invoke')
  */
 final class RoutingConfigurator
@@ -28,13 +28,14 @@ final class RoutingConfigurator
         $this->routes[] = match ($name) {
             'head' => $this->route(Request::METHOD_HEAD, ...$arguments),
             'connect' => $this->route(Request::METHOD_CONNECT, ...$arguments),
+            'get' => $this->route(Request::METHOD_GET, ...$arguments),
             'post' => $this->route(Request::METHOD_POST, ...$arguments),
+            'put' => $this->route(Request::METHOD_PUT, ...$arguments),
+            'patch' => $this->route(Request::METHOD_PATCH, ...$arguments),
             'delete' => $this->route(Request::METHOD_DELETE, ...$arguments),
             'options' => $this->route(Request::METHOD_OPTIONS, ...$arguments),
-            'patch' => $this->route(Request::METHOD_PATCH, ...$arguments),
-            'put' => $this->route(Request::METHOD_PUT, ...$arguments),
             'trace' => $this->route(Request::METHOD_TRACE, ...$arguments),
-            default => $this->route(Request::METHOD_GET, ...$arguments),
+            default => throw new UnsupportedHttpMethodException($name),
         };
     }
 

--- a/src/Router/UnsupportedHttpMethodException.php
+++ b/src/Router/UnsupportedHttpMethodException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Router;
+
+use RuntimeException;
+
+final class UnsupportedHttpMethodException extends RuntimeException
+{
+    public function __construct(string $name)
+    {
+        parent::__construct("Unsupported HTTP method '{$name}'");
+    }
+}

--- a/tests/Unit/Router/RouteTest.php
+++ b/tests/Unit/Router/RouteTest.php
@@ -7,6 +7,7 @@ namespace GacelaTest\Unit\Router;
 use Gacela\Router\Request;
 use Gacela\Router\Route;
 use Gacela\Router\RoutingConfigurator;
+use Gacela\Router\UnsupportedHttpMethodException;
 use Generator;
 use PHPUnit\Framework\TestCase;
 
@@ -211,6 +212,15 @@ final class RouteTest extends TestCase
 
         Route::configure(static function (RoutingConfigurator $routes): void {
             $routes->get('optional/{param1?}/{param2?}', FakeController::class, 'basicAction');
+        });
+    }
+
+    public function test_it_should_thrown_exception_if_method_does_not_exist(): void
+    {
+        $this->expectException(UnsupportedHttpMethodException::class);
+
+        Route::configure(static function (RoutingConfigurator $routes): void {
+            $routes->invalidName('', FakeController::class);
         });
     }
 }


### PR DESCRIPTION
## 📚 Description

Reference: https://github.com/gacela-project/router/pull/1#discussion_r1162857357

It should not be possible to define an invalid `HTTP verb` in the `RoutingConfigurator` class.