### PR TITLE
Support all routes with "any"

### DIFF
--- a/src/Router/Request.php
+++ b/src/Router/Request.php
@@ -15,6 +15,18 @@ final class Request
     public const METHOD_POST = 'POST';
     public const METHOD_PUT = 'PUT';
     public const METHOD_TRACE = 'TRACE';
+    public const ALL_METHODS = [
+        self::METHOD_CONNECT,
+        self::METHOD_DELETE,
+        self::METHOD_GET,
+        self::METHOD_HEAD,
+        self::METHOD_OPTIONS,
+        self::METHOD_PATCH,
+        self::METHOD_POST,
+        self::METHOD_PUT,
+        self::METHOD_TRACE,
+    ];
+
     private static ?self $instance = null;
 
     private function __construct(

--- a/src/Router/RoutingConfigurator.php
+++ b/src/Router/RoutingConfigurator.php
@@ -27,22 +27,9 @@ final class RoutingConfigurator
     public function __call(string $name, array $arguments): void
     {
         if ($name === 'any') {
-            foreach (Request::ALL_METHODS as $methodName) {
-                $this->routes[] = $this->route($methodName, ...$arguments);
-            }
+            $this->addRoutesForAllMethods($arguments);
         } else {
-            $this->routes[] =  match ($name) {
-                'head' => $this->route(Request::METHOD_HEAD, ...$arguments),
-                'connect' => $this->route(Request::METHOD_CONNECT, ...$arguments),
-                'get' => $this->route(Request::METHOD_GET, ...$arguments),
-                'post' => $this->route(Request::METHOD_POST, ...$arguments),
-                'put' => $this->route(Request::METHOD_PUT, ...$arguments),
-                'patch' => $this->route(Request::METHOD_PATCH, ...$arguments),
-                'delete' => $this->route(Request::METHOD_DELETE, ...$arguments),
-                'options' => $this->route(Request::METHOD_OPTIONS, ...$arguments),
-                'trace' => $this->route(Request::METHOD_TRACE, ...$arguments),
-                default => throw new UnsupportedHttpMethodException($name),
-            };
+            $this->addRouteByName($name, $arguments);
         }
     }
 
@@ -55,9 +42,38 @@ final class RoutingConfigurator
     }
 
     /**
+     * @psalm-suppress MixedArgument
+     */
+    private function addRoutesForAllMethods(array $arguments): void
+    {
+        foreach (Request::ALL_METHODS as $methodName) {
+            $this->routes[] = $this->createRoute($methodName, ...$arguments);
+        }
+    }
+
+    /**
+     * @psalm-suppress MixedArgument
+     */
+    private function addRouteByName(string $name, array $arguments): void
+    {
+        $this->routes[] = match ($name) {
+            'head' => $this->createRoute(Request::METHOD_HEAD, ...$arguments),
+            'connect' => $this->createRoute(Request::METHOD_CONNECT, ...$arguments),
+            'get' => $this->createRoute(Request::METHOD_GET, ...$arguments),
+            'post' => $this->createRoute(Request::METHOD_POST, ...$arguments),
+            'delete' => $this->createRoute(Request::METHOD_DELETE, ...$arguments),
+            'options' => $this->createRoute(Request::METHOD_OPTIONS, ...$arguments),
+            'patch' => $this->createRoute(Request::METHOD_PATCH, ...$arguments),
+            'put' => $this->createRoute(Request::METHOD_PUT, ...$arguments),
+            'trace' => $this->createRoute(Request::METHOD_TRACE, ...$arguments),
+            default => throw new UnsupportedHttpMethodException($name),
+        };
+    }
+
+    /**
      * @param object|class-string $controller
      */
-    private function route(
+    private function createRoute(
         string $method,
         string $path,
         object|string $controller,

--- a/src/Router/RoutingConfigurator.php
+++ b/src/Router/RoutingConfigurator.php
@@ -14,6 +14,7 @@ namespace Gacela\Router;
  * @method delete(string $path, object|string $controller, string $action = '__invoke')
  * @method options(string $path, object|string $controller, string $action = '__invoke')
  * @method trace(string $path, object|string $controller, string $action = '__invoke')
+ * @method any(string $path, object|string $controller, string $action = '__invoke')
  */
 final class RoutingConfigurator
 {
@@ -25,18 +26,24 @@ final class RoutingConfigurator
      */
     public function __call(string $name, array $arguments): void
     {
-        $this->routes[] = match ($name) {
-            'head' => $this->route(Request::METHOD_HEAD, ...$arguments),
-            'connect' => $this->route(Request::METHOD_CONNECT, ...$arguments),
-            'get' => $this->route(Request::METHOD_GET, ...$arguments),
-            'post' => $this->route(Request::METHOD_POST, ...$arguments),
-            'put' => $this->route(Request::METHOD_PUT, ...$arguments),
-            'patch' => $this->route(Request::METHOD_PATCH, ...$arguments),
-            'delete' => $this->route(Request::METHOD_DELETE, ...$arguments),
-            'options' => $this->route(Request::METHOD_OPTIONS, ...$arguments),
-            'trace' => $this->route(Request::METHOD_TRACE, ...$arguments),
-            default => throw new UnsupportedHttpMethodException($name),
-        };
+        if ($name === 'any') {
+            foreach (Request::ALL_METHODS as $methodName) {
+                $this->routes[] = $this->route($methodName, ...$arguments);
+            }
+        } else {
+            $this->routes[] =  match ($name) {
+                'head' => $this->route(Request::METHOD_HEAD, ...$arguments),
+                'connect' => $this->route(Request::METHOD_CONNECT, ...$arguments),
+                'get' => $this->route(Request::METHOD_GET, ...$arguments),
+                'post' => $this->route(Request::METHOD_POST, ...$arguments),
+                'put' => $this->route(Request::METHOD_PUT, ...$arguments),
+                'patch' => $this->route(Request::METHOD_PATCH, ...$arguments),
+                'delete' => $this->route(Request::METHOD_DELETE, ...$arguments),
+                'options' => $this->route(Request::METHOD_OPTIONS, ...$arguments),
+                'trace' => $this->route(Request::METHOD_TRACE, ...$arguments),
+                default => throw new UnsupportedHttpMethodException($name),
+            };
+        }
     }
 
     /**

--- a/tests/Unit/Router/RouteTest.php
+++ b/tests/Unit/Router/RouteTest.php
@@ -211,7 +211,7 @@ final class RouteTest extends TestCase
         $this->expectOutputString('Expected!');
 
         Route::configure(static function (RoutingConfigurator $routes): void {
-            $routes->any('optional/{param1?}/{param2?}', FakeController::class, 'basicAction');
+            $routes->get('optional/{param1?}/{param2?}', FakeController::class, 'basicAction');
         });
     }
 

--- a/tests/Unit/Router/RouteTest.php
+++ b/tests/Unit/Router/RouteTest.php
@@ -15,7 +15,7 @@ final class RouteTest extends TestCase
 {
     private const PROVIDER_TRIES = 10;
 
-    protected function tearDown(): void
+    protected function setUp(): void
     {
         Request::resetCache();
     }
@@ -211,7 +211,7 @@ final class RouteTest extends TestCase
         $this->expectOutputString('Expected!');
 
         Route::configure(static function (RoutingConfigurator $routes): void {
-            $routes->get('optional/{param1?}/{param2?}', FakeController::class, 'basicAction');
+            $routes->any('optional/{param1?}/{param2?}', FakeController::class, 'basicAction');
         });
     }
 
@@ -222,5 +222,33 @@ final class RouteTest extends TestCase
         Route::configure(static function (RoutingConfigurator $routes): void {
             $routes->invalidName('', FakeController::class);
         });
+    }
+
+    /**
+     * @dataProvider anyHttpMethodProvider
+     */
+    public function test_any_http_method(string $httpMethod): void
+    {
+        $_SERVER['REQUEST_URI'] = 'https://example.org/expected/uri';
+        $_SERVER['REQUEST_METHOD'] = $httpMethod;
+
+        $this->expectOutputString('Expected!');
+
+        Route::configure(static function (RoutingConfigurator $routes): void {
+            $routes->any('expected/uri', FakeController::class, 'basicAction');
+        });
+    }
+
+    public function anyHttpMethodProvider(): Generator
+    {
+        yield ['METHOD_GET' => Request::METHOD_GET];
+        yield ['METHOD_CONNECT' => Request::METHOD_CONNECT];
+        yield ['METHOD_DELETE' => Request::METHOD_DELETE];
+        yield ['METHOD_HEAD' => Request::METHOD_HEAD];
+        yield ['METHOD_OPTIONS' => Request::METHOD_OPTIONS];
+        yield ['METHOD_PATCH' => Request::METHOD_PATCH];
+        yield ['METHOD_POST' => Request::METHOD_POST];
+        yield ['METHOD_PUT' => Request::METHOD_PUT];
+        yield ['METHOD_TRACE' => Request::METHOD_TRACE];
     }
 }


### PR DESCRIPTION
## 📚 Description

Right now, if you want to support the same url path for all methods, you have to write it down one by one.

## 🔖 Changes

- Add `any()` to allow all HTTP methods for a particular url path
