### PR TITLE
Inject Request in Controller's constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,17 +45,17 @@ You can access the example routes:
 ```php
 # file: example/example.php
 Router::configure(static function (Routes $routes, MappingInterfaces $mappingInterfaces) void {
+    # http://localhost:8081/docs
     $routes->redirect('docs', 'https://gacela-project.com/');
 
-    # localhost:8081/custom/123
+    # http://localhost:8081?number=456
+    $routes->get('/', CustomController::class);
+    
+    # http://localhost:8081/custom/123
     $routes->get('custom/{number}', CustomControllerWithDependencies::class, 'customAction');
     $mappingInterfaces->add(SomeDependencyInterface::class, SomeDependencyConcrete::class)
 
-    # localhost:8081/custom
-    $routes->get('custom', CustomController::class);
-
-    # localhost:8081?number=456
-    $routes->get('/', CustomController::class);
+    # http://localhost:8081/custom
+    $routes->any('custom', CustomController::class);
 });
 ```
-

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
         }
     },
     "scripts": {
+        "serve": "php -S localhost:8081 example/example.php",
         "ctal": [
             "@static-clear-cache",
             "@csfix",

--- a/example/example.php
+++ b/example/example.php
@@ -8,13 +8,19 @@ use Gacela\Router\Entities\Request;
 use Gacela\Router\Router;
 use Gacela\Router\Routes;
 
-# php -S localhost:8081 example/example.php
+# To run this example locally, you can run in your terminal:
+# $ composer serve
 
-$controller = new class() {
+class Controller
+{
+    public function __construct(
+        private Request $request,
+    ) {
+    }
+
     public function __invoke(): string
     {
-        $request = Request::fromGlobals();
-        $number = $request->get('number');
+        $number = $this->request->get('number');
 
         if (!empty($number)) {
             return "__invoke with GET 'number'={$number}";
@@ -27,17 +33,18 @@ $controller = new class() {
     {
         return "customAction(number: {$number})";
     }
-};
+}
 
-Router::configure(static function (Routes $routes) use ($controller): void {
+Router::configure(static function (Routes $routes): void {
+    # Try it out: http://localhost:8081/docs
     $routes->redirect('docs', 'https://gacela-project.com/');
 
-    # localhost:8081/custom/123
-    $routes->get('custom/{number}', $controller, 'customAction');
+    # Try it out: http://localhost:8081?number=456
+    $routes->get('/', Controller::class);
 
-    # localhost:8081/custom
-    $routes->get('custom', $controller);
+    # Try it out: http://localhost:8081/custom/123
+    $routes->get('custom/{number}', Controller::class, 'customAction');
 
-    # localhost:8081?number=456
-    $routes->get('/', $controller);
+    # Try it out: http://localhost:8081/custom
+    $routes->any('custom', Controller::class);
 });

--- a/src/Router/MappingInterfaces.php
+++ b/src/Router/MappingInterfaces.php
@@ -4,10 +4,17 @@ declare(strict_types=1);
 
 namespace Gacela\Router;
 
+use Gacela\Router\Entities\Request;
+
 final class MappingInterfaces
 {
     /** @var array<class-string, callable|class-string|object> */
     private array $mappingInterfaces = [];
+
+    public function __construct()
+    {
+        $this->builtInInjections();
+    }
 
     /**
      * @param class-string $name
@@ -25,5 +32,10 @@ final class MappingInterfaces
     public function getAll(): array
     {
         return $this->mappingInterfaces;
+    }
+
+    private function builtInInjections(): void
+    {
+        $this->add(Request::class, Request::fromGlobals());
     }
 }

--- a/tests/Unit/Router/Fixtures/FakeControllerWithRequest.php
+++ b/tests/Unit/Router/Fixtures/FakeControllerWithRequest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Router\Fixtures;
+
+use Gacela\Router\Entities\Request;
+
+final class FakeControllerWithRequest
+{
+    public function __construct(
+        private Request $request,
+    ) {
+    }
+
+    public function __invoke(): string
+    {
+        return (string)$this->request->get('name');
+    }
+}

--- a/tests/Unit/Router/RouterRedirectTest.php
+++ b/tests/Unit/Router/RouterRedirectTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\TestCase;
 
 include_once __DIR__ . '/Fake/header.php';
 
-final class RoutingRedirectTest extends TestCase
+final class RouterRedirectTest extends TestCase
 {
     use HeadersTearDown;
 

--- a/tests/Unit/Router/RouterTest.php
+++ b/tests/Unit/Router/RouterTest.php
@@ -13,10 +13,11 @@ use GacelaTest\Unit\Router\Fake\Name;
 use GacelaTest\Unit\Router\Fake\NameInterface;
 use GacelaTest\Unit\Router\Fixtures\FakeController;
 use GacelaTest\Unit\Router\Fixtures\FakeControllerWithDependencies;
+use GacelaTest\Unit\Router\Fixtures\FakeControllerWithRequest;
 use Generator;
 use PHPUnit\Framework\TestCase;
 
-final class RoutingTest extends TestCase
+final class RouterTest extends TestCase
 {
     private const PROVIDER_TRIES = 10;
 
@@ -58,7 +59,6 @@ final class RoutingTest extends TestCase
 
     public function test_it_should_pass_many_params_to_the_action(): void
     {
-        /** @var list<string> $params */
         $params = ['foo', 'bar', 'baz'];
 
         $_SERVER['REQUEST_URI'] = "https://example.org/{$params[0]}/{$params[1]}/{$params[2]}";
@@ -73,7 +73,6 @@ final class RoutingTest extends TestCase
 
     public function test_it_should_pass_associated_params_by_name_to_the_action(): void
     {
-        /** @var list<string> $params */
         $params = ['foo', 'bar', 'baz'];
 
         $_SERVER['REQUEST_URI'] = "https://example.org/{$params[0]}/{$params[1]}/{$params[2]}";
@@ -262,6 +261,19 @@ final class RoutingTest extends TestCase
         Router::configure(static function (Routes $routes, MappingInterfaces $mappingInterfaces): void {
             $routes->get('expected/uri', FakeControllerWithDependencies::class);
             $mappingInterfaces->add(NameInterface::class, new Name('Expected!'));
+        });
+    }
+
+    public function test_inject_controller_with_request_dependency(): void
+    {
+        $_SERVER['REQUEST_URI'] = 'https://example.org/expected';
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        $_GET['name'] = 'Katarn';
+
+        $this->expectOutputString('Katarn');
+
+        Router::configure(static function (Routes $routes): void {
+            $routes->get('expected', FakeControllerWithRequest::class);
         });
     }
 }


### PR DESCRIPTION
## 📚 Description

Inject in `$mappingInterfaces` the `Request` object by default in controllers.

## 🔖 Changes

- Add `composer serve` command
- Resolve `Request` object from `Request::fromGlobals()` automagically
- Improve documentation (`README` & some comments)
