### PR TITLE
Create JsonResponse

### DIFF
--- a/src/Router/Entities/JsonResponse.php
+++ b/src/Router/Entities/JsonResponse.php
@@ -13,7 +13,7 @@ final class JsonResponse
 
     public function __toString(): string
     {
-        //        header('Content-Type: application/json');
+        header('Content-Type: application/json');
 
         return json_encode($this->json, JSON_THROW_ON_ERROR);
     }

--- a/src/Router/Entities/JsonResponse.php
+++ b/src/Router/Entities/JsonResponse.php
@@ -4,17 +4,17 @@ declare(strict_types=1);
 
 namespace Gacela\Router\Entities;
 
-final class JsonResponse
+final class JsonResponse extends Response
 {
-    public function __construct(
-        private array $json,
-    ) {
+    public function __construct(array $json)
+    {
+        parent::__construct(json_encode($json, JSON_THROW_ON_ERROR));
     }
 
     public function __toString(): string
     {
         header('Content-Type: application/json');
 
-        return json_encode($this->json, JSON_THROW_ON_ERROR);
+        return parent::__toString();
     }
 }

--- a/src/Router/Entities/JsonResponse.php
+++ b/src/Router/Entities/JsonResponse.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Router\Entities;
+
+final class JsonResponse
+{
+    public function __construct(
+        private array $json,
+    ) {
+    }
+
+    public function __toString(): string
+    {
+        //        header('Content-Type: application/json');
+
+        return json_encode($this->json, JSON_THROW_ON_ERROR);
+    }
+}

--- a/src/Router/Entities/Response.php
+++ b/src/Router/Entities/Response.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Router\Entities;
+
+class Response
+{
+    public function __construct(
+        private string $body,
+    ) {
+    }
+
+    public function __toString(): string
+    {
+        return $this->body;
+    }
+}

--- a/tests/Feature/HeaderTestCase.php
+++ b/tests/Feature/HeaderTestCase.php
@@ -24,6 +24,6 @@ abstract class HeaderTestCase extends TestCase
     {
         global $testHeaders;
 
-        return $testHeaders;
+        return $testHeaders ?? [];
     }
 }

--- a/tests/Feature/Router/RouterJsonResponseTest.php
+++ b/tests/Feature/Router/RouterJsonResponseTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Router;
+
+use Gacela\Router\Entities\JsonResponse;
+use Gacela\Router\Entities\Request;
+use Gacela\Router\Router;
+use Gacela\Router\Routes;
+use GacelaTest\Feature\HeaderTestCase;
+
+final class RouterJsonResponseTest extends HeaderTestCase
+{
+    public function test_simple_redirect(): void
+    {
+        $_SERVER['REQUEST_URI'] = 'https://example.org/optional/uri';
+        $_SERVER['REQUEST_METHOD'] = Request::METHOD_GET;
+
+        Router::configure(static function (Routes $routes): void {
+            $routes->get('optional/uri', static fn () => new JsonResponse([
+                'key' => 'value',
+            ]));
+        });
+
+        $this->expectOutputString(json_encode(['key' => 'value']));
+
+        //        self::assertSame([
+        //            [
+        //                'header' => 'Content-Type: application/json',
+        //                'replace' => true,
+        //                'response_code' => 0,
+        //            ],
+        //        ], $this->headers());
+    }
+}

--- a/tests/Feature/Router/RouterJsonResponseTest.php
+++ b/tests/Feature/Router/RouterJsonResponseTest.php
@@ -23,14 +23,14 @@ final class RouterJsonResponseTest extends HeaderTestCase
             ]));
         });
 
-        $this->expectOutputString(json_encode(['key' => 'value']));
+        $this->expectOutputString('{"key":"value"}');
 
-        //        self::assertSame([
-        //            [
-        //                'header' => 'Content-Type: application/json',
-        //                'replace' => true,
-        //                'response_code' => 0,
-        //            ],
-        //        ], $this->headers());
+        self::assertSame([
+            [
+                'header' => 'Content-Type: application/json',
+                'replace' => true,
+                'response_code' => 0,
+            ],
+        ], $this->headers());
     }
 }

--- a/tests/Feature/Router/RouterResponseTest.php
+++ b/tests/Feature/Router/RouterResponseTest.php
@@ -6,19 +6,34 @@ namespace GacelaTest\Feature\Router;
 
 use Gacela\Router\Entities\JsonResponse;
 use Gacela\Router\Entities\Request;
+use Gacela\Router\Entities\Response;
 use Gacela\Router\Router;
 use Gacela\Router\Routes;
 use GacelaTest\Feature\HeaderTestCase;
 
-final class RouterJsonResponseTest extends HeaderTestCase
+final class RouterResponseTest extends HeaderTestCase
 {
-    public function test_simple_redirect(): void
+    public function test_string_response(): void
     {
-        $_SERVER['REQUEST_URI'] = 'https://example.org/optional/uri';
+        $_SERVER['REQUEST_URI'] = 'https://example.org/uri';
         $_SERVER['REQUEST_METHOD'] = Request::METHOD_GET;
 
         Router::configure(static function (Routes $routes): void {
-            $routes->get('optional/uri', static fn () => new JsonResponse([
+            $routes->get('uri', static fn () => new Response('body'));
+        });
+
+        $this->expectOutputString('body');
+
+        self::assertSame([], $this->headers());
+    }
+
+    public function test_json_response(): void
+    {
+        $_SERVER['REQUEST_URI'] = 'https://example.org/uri';
+        $_SERVER['REQUEST_METHOD'] = Request::METHOD_GET;
+
+        Router::configure(static function (Routes $routes): void {
+            $routes->get('uri', static fn () => new JsonResponse([
                 'key' => 'value',
             ]));
         });

--- a/tests/Feature/header.php
+++ b/tests/Feature/header.php
@@ -59,3 +59,23 @@ namespace Gacela\Router\Controllers {
         ];
     }
 }
+
+// TODO: Find a better way to mock the head function in different namespaces
+
+namespace Gacela\Router\Entities {
+    function header(string $header, bool $replace = true, int $responseCode = 0): void
+    {
+        /** @var list<array{header: string, replace: boolean, response_code: int}> | null $testHeaders */
+        global $testHeaders;
+
+        if (!\is_array($testHeaders)) {
+            $testHeaders = [];
+        }
+
+        $testHeaders[] = [
+            'header' => $header,
+            'replace' => $replace,
+            'response_code' => $responseCode,
+        ];
+    }
+}


### PR DESCRIPTION
## 📚 Description

The main motivation is to get rid of this json header from the client side: 
https://github.com/gacela-project/api-skeleton/blob/main/public/index.php#L18 

<img width="639" alt="Screenshot 2023-04-21 at 23 41 59" src="https://user-images.githubusercontent.com/5256287/233739031-ceebecb4-caa6-4d7b-a72f-ffdf380f0fc6.png">

## 🔖 Changes

- Create Response class
- Create JsonResponse class (which extends Response)

The aim is to be able to use `JsonResponse` which receives an array,
and it converts it to a json and adds the proper json header. Eg:

<img width="951" alt="Screenshot 2023-04-21 at 23 30 15" src="https://user-images.githubusercontent.com/5256287/233737694-16cb2660-dccf-4bc9-b9d9-ef0af6caaa02.png">

## 🤔 Follow up

How can we get rid of the other custom headers?
Eg: in the first screenshot, line 17: `header('Access-Control-Allow-Origin: *');`
