### PR TITLE
Allow headers in Response

### DIFF
--- a/example/example.php
+++ b/example/example.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 require_once \dirname(__DIR__) . '/vendor/autoload.php';
 
 use Gacela\Router\Entities\Request;
+use Gacela\Router\Entities\Response;
 use Gacela\Router\Router;
 use Gacela\Router\Routes;
 
@@ -34,6 +35,14 @@ class Controller
     {
         return "customAction(number: {$number})";
     }
+
+    public function customHeaders(): Response
+    {
+        return new Response('{"custom": "headers"}', [
+            'Access-Control-Allow-Origin: *',
+            'Content-Type: application/json',
+        ]);
+    }
 }
 
 Router::configure(static function (Routes $routes): void {
@@ -48,4 +57,7 @@ Router::configure(static function (Routes $routes): void {
 
     # Try it out: http://localhost:8081/custom
     $routes->any('custom', Controller::class);
+
+    # Try it out: http://localhost:8081/headers
+    $routes->any('headers', Controller::class, 'customHeaders');
 });

--- a/src/Router/Entities/JsonResponse.php
+++ b/src/Router/Entities/JsonResponse.php
@@ -4,17 +4,18 @@ declare(strict_types=1);
 
 namespace Gacela\Router\Entities;
 
+use function in_array;
+
 final class JsonResponse extends Response
 {
+    /**
+     * @param list<string> $headers
+     */
     public function __construct(array $json, array $headers = [])
     {
+        if (!in_array('Content-Type: application/json', $headers, true)) {
+            $headers[] = 'Content-Type: application/json';
+        }
         parent::__construct(json_encode($json, JSON_THROW_ON_ERROR), $headers);
-    }
-
-    public function __toString(): string
-    {
-        header('Content-Type: application/json');
-
-        return parent::__toString();
     }
 }

--- a/src/Router/Entities/JsonResponse.php
+++ b/src/Router/Entities/JsonResponse.php
@@ -6,9 +6,9 @@ namespace Gacela\Router\Entities;
 
 final class JsonResponse extends Response
 {
-    public function __construct(array $json)
+    public function __construct(array $json, array $headers = [])
     {
-        parent::__construct(json_encode($json, JSON_THROW_ON_ERROR));
+        parent::__construct(json_encode($json, JSON_THROW_ON_ERROR), $headers);
     }
 
     public function __toString(): string

--- a/src/Router/Entities/Response.php
+++ b/src/Router/Entities/Response.php
@@ -6,13 +6,21 @@ namespace Gacela\Router\Entities;
 
 class Response
 {
+    /**
+     * @param list<string> $headers
+     */
     public function __construct(
-        private string $body,
+        private string $content,
+        private array $headers = [],
     ) {
     }
 
     public function __toString(): string
     {
-        return $this->body;
+        foreach ($this->headers as $header) {
+            header($header);
+        }
+
+        return $this->content;
     }
 }

--- a/tests/Feature/Router/RouterResponseTest.php
+++ b/tests/Feature/Router/RouterResponseTest.php
@@ -48,4 +48,32 @@ final class RouterResponseTest extends HeaderTestCase
             ],
         ], $this->headers());
     }
+
+    public function test_response_headers(): void
+    {
+        $_SERVER['REQUEST_URI'] = 'https://example.org/uri';
+        $_SERVER['REQUEST_METHOD'] = Request::METHOD_GET;
+
+        Router::configure(static function (Routes $routes): void {
+            $routes->get('uri', static fn () => new Response('{"key":"value"}', [
+                'Access-Control-Allow-Origin: *',
+                'Content-Type: application/json',
+            ]));
+        });
+
+        $this->expectOutputString('{"key":"value"}');
+
+        self::assertSame([
+            [
+                'header' => 'Access-Control-Allow-Origin: *',
+                'replace' => true,
+                'response_code' => 0,
+            ],
+            [
+                'header' => 'Content-Type: application/json',
+                'replace' => true,
+                'response_code' => 0,
+            ],
+        ], $this->headers());
+    }
 }

--- a/tests/Feature/Router/RouterResponseTest.php
+++ b/tests/Feature/Router/RouterResponseTest.php
@@ -76,4 +76,32 @@ final class RouterResponseTest extends HeaderTestCase
             ],
         ], $this->headers());
     }
+
+    public function test_json_response_headers(): void
+    {
+        $_SERVER['REQUEST_URI'] = 'https://example.org/uri';
+        $_SERVER['REQUEST_METHOD'] = Request::METHOD_GET;
+
+        Router::configure(static function (Routes $routes): void {
+            $routes->get('uri', static fn () => new JsonResponse(['key' => 'value'], [
+                'Access-Control-Allow-Origin: *',
+                'Content-Type: application/json',
+            ]));
+        });
+
+        $this->expectOutputString('{"key":"value"}');
+
+        self::assertSame([
+            [
+                'header' => 'Access-Control-Allow-Origin: *',
+                'replace' => true,
+                'response_code' => 0,
+            ],
+            [
+                'header' => 'Content-Type: application/json',
+                'replace' => true,
+                'response_code' => 0,
+            ],
+        ], $this->headers());
+    }
 }


### PR DESCRIPTION
## 📚 Description

We want to allow an easy way to define custom/multiple headers within a Response object.

## 🔖 Changes

- Add an additional/optional argument to the Response constructor where you can specify any additional headers.
