### PR TITLE
Require response to be a string or implements Stringable

### DIFF
--- a/src/Router/Controllers/RedirectController.php
+++ b/src/Router/Controllers/RedirectController.php
@@ -12,8 +12,9 @@ final class RedirectController
     ) {
     }
 
-    public function __invoke(): void
+    public function __invoke(): string
     {
         header('Location: ' . $this->destination, true, $this->status);
+        return '';
     }
 }

--- a/src/Router/Entities/Response.php
+++ b/src/Router/Entities/Response.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Gacela\Router\Entities;
 
-class Response
+use Stringable;
+
+class Response implements Stringable
 {
     /**
      * @param list<string> $headers

--- a/src/Router/Exceptions/UnsupportedResponseTypeException.php
+++ b/src/Router/Exceptions/UnsupportedResponseTypeException.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Router\Exceptions;
+
+use RuntimeException;
+
+use function get_class;
+use function gettype;
+
+final class UnsupportedResponseTypeException extends RuntimeException
+{
+    public static function fromType(mixed $var): self
+    {
+        $type = self::inferType($var);
+
+        return new self("Unsupported response type '{$type}'. Must be a string or implement Stringable interface.");
+    }
+
+    private static function inferType(mixed $var): string
+    {
+        $type = gettype($var);
+
+        if ($type === 'object') {
+            /** @var object $var */
+            return get_class($var);
+        }
+
+        return $type;
+    }
+}

--- a/tests/Feature/header.php
+++ b/tests/Feature/header.php
@@ -23,59 +23,32 @@ namespace Gacela\Router {
 // TODO: Find a better way to mock the head function in different namespaces
 
 namespace Gacela\Router\Handlers {
+    use function Gacela\Router\header as rootHeader;
+
     function header(string $header, bool $replace = true, int $responseCode = 0): void
     {
-        /** @var list<array{header: string, replace: boolean, response_code: int}> | null $testHeaders */
-        global $testHeaders;
-
-        if (!\is_array($testHeaders)) {
-            $testHeaders = [];
-        }
-
-        $testHeaders[] = [
-            'header' => $header,
-            'replace' => $replace,
-            'response_code' => $responseCode,
-        ];
+        rootHeader($header, $replace, $responseCode);
     }
 }
 
 // TODO: Find a better way to mock the head function in different namespaces
 
 namespace Gacela\Router\Controllers {
+    use function Gacela\Router\header as rootHeader;
+
     function header(string $header, bool $replace = true, int $responseCode = 0): void
     {
-        /** @var list<array{header: string, replace: boolean, response_code: int}> | null $testHeaders */
-        global $testHeaders;
-
-        if (!\is_array($testHeaders)) {
-            $testHeaders = [];
-        }
-
-        $testHeaders[] = [
-            'header' => $header,
-            'replace' => $replace,
-            'response_code' => $responseCode,
-        ];
+        rootHeader($header, $replace, $responseCode);
     }
 }
 
 // TODO: Find a better way to mock the head function in different namespaces
 
 namespace Gacela\Router\Entities {
+    use function Gacela\Router\header as rootHeader;
+
     function header(string $header, bool $replace = true, int $responseCode = 0): void
     {
-        /** @var list<array{header: string, replace: boolean, response_code: int}> | null $testHeaders */
-        global $testHeaders;
-
-        if (!\is_array($testHeaders)) {
-            $testHeaders = [];
-        }
-
-        $testHeaders[] = [
-            'header' => $header,
-            'replace' => $replace,
-            'response_code' => $responseCode,
-        ];
+        rootHeader($header, $replace, $responseCode);
     }
 }


### PR DESCRIPTION
## 📚 Description

To improve DX, we should ensure that the responses are strings or implement the Stringable interface (which was added in version 8.0 of PHP).

This was already being done accidentally, but now the code makes sure of it and throws a very clear exception to the developer if this is not the case.

This allows for more flexibility, for example, if someone is doing a simple CRUD, they could directly respond with their models in their controllers as long as they implement the Stringable interface (leaving aside opinions on whether this is more or less correct).

## 🔖 Changes

- Check if the response is a string or implements the Stringable interface.
- An exception is thrown in case it doesn't.
- Add new UnsupportedResponseTypeException.
- Built-in responses now implements the Stringable interface.
- Marginally improved the ñapa used to capture headers in the tests.
