### PR TITLE
Allow adding routes in different steps

### DIFF
--- a/example/example.php
+++ b/example/example.php
@@ -45,7 +45,9 @@ class Controller
     }
 }
 
-Router::configure(static function (Routes $routes): void {
+$router = Router::create();
+
+$router->addRoutes(static function (Routes $routes): void {
     # Try it out: http://localhost:8081/docs
     $routes->redirect('docs', 'https://gacela-project.com/');
 
@@ -61,3 +63,5 @@ Router::configure(static function (Routes $routes): void {
     # Try it out: http://localhost:8081/headers
     $routes->any('headers', Controller::class, 'customHeaders');
 });
+
+$router->run();

--- a/src/Router/Router.php
+++ b/src/Router/Router.php
@@ -16,7 +16,7 @@ use function is_callable;
 
 final class Router
 {
-    private function __construct(
+    public function __construct(
         private Routes $routes,
         private Bindings $bindings,
         private Handlers $handlers,

--- a/src/Router/Router.php
+++ b/src/Router/Router.php
@@ -16,26 +16,48 @@ use function is_callable;
 
 final class Router
 {
+    private function __construct(
+        private Routes $routes,
+        private Bindings $bindings,
+        private Handlers $handlers,
+    ) {
+    }
+
+    /**
+     * Shortcut to create, add and run all routes at once.
+     */
     public static function configure(Closure $fn): void
     {
-        $routes = new Routes();
-        $bindings = new Bindings();
-        $handlers = new Handlers();
+        $self = self::create();
+        $self->addRoutes($fn);
+        $self->run();
+    }
 
-        $params = array_map(static fn ($param) => match ((string)$param->getType()) {
-            Routes::class => $routes,
-            Bindings::class => $bindings,
-            Handlers::class => $handlers,
+    public static function create(): self
+    {
+        return new self(new Routes(), new Bindings(), new Handlers());
+    }
+
+    public function addRoutes(Closure $fn): self
+    {
+        $params = array_map(fn ($param) => match ((string)$param->getType()) {
+            Routes::class => $this->routes,
+            Bindings::class => $this->bindings,
+            Handlers::class => $this->handlers,
             default => null,
         }, (new ReflectionFunction($fn))->getParameters());
 
         $fn(...$params);
 
+        return $this;
+    }
+
+    public function run(): void
+    {
         try {
-            echo self::findRoute($routes)
-                ->run($bindings);
+            echo self::findRoute($this->routes)->run($this->bindings);
         } catch (Exception $exception) {
-            echo self::handleException($handlers, $exception);
+            echo self::handleException($this->handlers, $exception);
         }
     }
 

--- a/tests/Feature/Router/RouterRunTest.php
+++ b/tests/Feature/Router/RouterRunTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Router;
+
+use Gacela\Router\Entities\Request;
+use Gacela\Router\Entities\Response;
+use Gacela\Router\Router;
+use Gacela\Router\Routes;
+use GacelaTest\Feature\HeaderTestCase;
+
+final class RouterRunTest extends HeaderTestCase
+{
+    public function test_run_multiple_route_collections(): void
+    {
+        $_SERVER['REQUEST_URI'] = 'https://example.org/uri-2';
+        $_SERVER['REQUEST_METHOD'] = Request::METHOD_GET;
+
+        $router = Router::create();
+
+        $router->addRoutes(static function (Routes $routes): void {
+            $routes->get('uri-1', static fn () => new Response('first body'));
+        });
+
+        $router->addRoutes(static function (Routes $routes): void {
+            $routes->get('uri-2', static fn () => new Response('second body'));
+        });
+
+        $router->run();
+
+        $this->expectOutputString('second body');
+
+        self::assertSame([], $this->headers());
+    }
+
+    public function test_run_same_multiple_route_collections_then_first_with_priority(): void
+    {
+        $_SERVER['REQUEST_URI'] = 'https://example.org/uri';
+        $_SERVER['REQUEST_METHOD'] = Request::METHOD_GET;
+
+        $router = Router::create();
+
+        $router->addRoutes(static function (Routes $routes): void {
+            $routes->get('uri', static fn () => new Response('first body'));
+        });
+
+        $router->addRoutes(static function (Routes $routes): void {
+            $routes->get('uri', static fn () => new Response('second body'));
+        });
+
+        $router->run();
+
+        $this->expectOutputString('first body');
+
+        self::assertSame([], $this->headers());
+    }
+}


### PR DESCRIPTION
## 📚 Description

Idea: https://github.com/gacela-project/router/issues/25

## 🔖 Changes

- Split the `Router::configure()` into different object methods, so this can be called in different steps/modules
