### PR TITLE
Refactor Router Static Methods

### DIFF
--- a/src/Router/Router.php
+++ b/src/Router/Router.php
@@ -55,15 +55,15 @@ final class Router
     public function run(): void
     {
         try {
-            echo self::findRoute($this->routes)->run($this->bindings);
+            echo $this->findRoute()->run($this->bindings);
         } catch (Exception $exception) {
             echo self::handleException($this->handlers, $exception);
         }
     }
 
-    private static function findRoute(Routes $routes): Route
+    private function findRoute(): Route
     {
-        foreach ($routes->getAllRoutes() as $route) {
+        foreach ($this->routes->getAllRoutes() as $route) {
             if ($route->requestMatches()) {
                 return $route;
             }

--- a/src/Router/Router.php
+++ b/src/Router/Router.php
@@ -74,7 +74,7 @@ final class Router
 
     private function handleException(Exception $exception): string
     {
-        $handler = self::findHandler($this->handlers, $exception);
+        $handler = $this->findHandler($exception);
 
         if (is_callable($handler)) {
             return $handler($exception);
@@ -93,9 +93,9 @@ final class Router
     /**
      * @return callable|class-string
      */
-    private static function findHandler(Handlers $handlers, Exception $exception): string|callable
+    private function findHandler(Exception $exception): string|callable
     {
-        return $handlers->getAllHandlers()[get_class($exception)]
-            ?? $handlers->getAllHandlers()[Exception::class];
+        return $this->handlers->getAllHandlers()[get_class($exception)]
+            ?? $this->handlers->getAllHandlers()[Exception::class];
     }
 }

--- a/src/Router/Router.php
+++ b/src/Router/Router.php
@@ -57,7 +57,7 @@ final class Router
         try {
             echo $this->findRoute()->run($this->bindings);
         } catch (Exception $exception) {
-            echo self::handleException($this->handlers, $exception);
+            echo $this->handleException($exception);
         }
     }
 
@@ -72,9 +72,9 @@ final class Router
         throw new NotFound404Exception();
     }
 
-    private static function handleException(Handlers $handlers, Exception $exception): string
+    private function handleException(Exception $exception): string
     {
-        $handler = self::findHandler($handlers, $exception);
+        $handler = self::findHandler($this->handlers, $exception);
 
         if (is_callable($handler)) {
             return $handler($exception);


### PR DESCRIPTION
## 📚 Description

Now that the Router is instantiable, it doesn't make sense for the findRoute, handleException, and findHandler methods to require the routes and handlers as props. Instead, I have made these methods non-static and they now directly retrieve these values from the instance's attributes.