### PR TITLE
Unify Router use

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ composer require gacela-project/router
 ```php
 # `Bindings` and `Handlers` are optional, and you can place them in any order.
 
-Router::configure(static function (Routes $routes, Bindings $bindings, Handlers $handlers) void {
+$router = new Router(static function (Routes $routes, Bindings $bindings, Handlers $handlers) void {
 
     // Custom redirections
     $routes->redirect('docs', 'https://gacela-project.com/');
@@ -60,6 +60,8 @@ Router::configure(static function (Routes $routes, Bindings $bindings, Handlers 
     $handlers->handle(NotFound404Exception::class, NotFound404ExceptionHandler::class);
 
 });
+
+$router->run();
 ```
 
 ### Working demo

--- a/example/example.php
+++ b/example/example.php
@@ -45,9 +45,7 @@ class Controller
     }
 }
 
-$router = Router::create();
-
-$router->addRoutes(static function (Routes $routes): void {
+$router = new Router(static function (Routes $routes): void {
     # Try it out: http://localhost:8081/docs
     $routes->redirect('docs', 'https://gacela-project.com/');
 

--- a/src/Router/Router.php
+++ b/src/Router/Router.php
@@ -13,32 +13,27 @@ use ReflectionFunction;
 
 use function get_class;
 use function is_callable;
+use function is_null;
 
 final class Router
 {
+    private Routes $routes;
+    private Bindings $bindings;
+    private Handlers $handlers;
+
     public function __construct(
-        private Routes $routes,
-        private Bindings $bindings,
-        private Handlers $handlers,
+        Closure $fn = null,
     ) {
+        $this->routes = new Routes();
+        $this->bindings = new Bindings();
+        $this->handlers = new Handlers();
+
+        if (!is_null($fn)) {
+            $this->configure($fn);
+        }
     }
 
-    /**
-     * Shortcut to create, add and run all routes at once.
-     */
-    public static function configure(Closure $fn): void
-    {
-        $self = self::create();
-        $self->addRoutes($fn);
-        $self->run();
-    }
-
-    public static function create(): self
-    {
-        return new self(new Routes(), new Bindings(), new Handlers());
-    }
-
-    public function addRoutes(Closure $fn): self
+    public function configure(Closure $fn): self
     {
         $params = array_map(fn ($param) => match ((string)$param->getType()) {
             Routes::class => $this->routes,

--- a/tests/Feature/Router/ErrorHandlingTest.php
+++ b/tests/Feature/Router/ErrorHandlingTest.php
@@ -25,8 +25,9 @@ final class ErrorHandlingTest extends HeaderTestCase
         $_SERVER['REQUEST_URI'] = 'https://example.org/optional/uri';
         $_SERVER['REQUEST_METHOD'] = Request::METHOD_OPTIONS;
 
-        Router::configure(static function (): void {
+        $router = new Router(static function (): void {
         });
+        $router->run();
 
         self::assertSame([
             [
@@ -42,9 +43,10 @@ final class ErrorHandlingTest extends HeaderTestCase
         $_SERVER['REQUEST_URI'] = 'https://example.org/expected/uri';
         $_SERVER['REQUEST_METHOD'] = Request::METHOD_GET;
 
-        Router::configure(static function (Routes $routes): void {
+        $router = new Router(static function (Routes $routes): void {
             $routes->post('expected/uri', FakeController::class, 'basicAction');
         });
+        $router->run();
 
         self::assertSame([
             [
@@ -63,9 +65,10 @@ final class ErrorHandlingTest extends HeaderTestCase
         $_SERVER['REQUEST_URI'] = 'https://example.org/expected/uri';
         $_SERVER['REQUEST_METHOD'] = $testMethod;
 
-        Router::configure(static function (Routes $routes) use ($givenMethods): void {
+        $router = new Router(static function (Routes $routes) use ($givenMethods): void {
             $routes->match($givenMethods, 'expected/uri', FakeController::class, 'basicAction');
         });
+        $router->run();
 
         self::assertSame([
             [
@@ -92,9 +95,10 @@ final class ErrorHandlingTest extends HeaderTestCase
         $_SERVER['REQUEST_URI'] = 'https://example.org/expected/uri';
         $_SERVER['REQUEST_METHOD'] = Request::METHOD_GET;
 
-        Router::configure(static function (Routes $routes): void {
+        $router = new Router(static function (Routes $routes): void {
             $routes->get('expected/uri', FakeControllerWithUnhandledException::class);
         });
+        $router->run();
 
         self::assertSame([
             [
@@ -110,7 +114,7 @@ final class ErrorHandlingTest extends HeaderTestCase
         $_SERVER['REQUEST_URI'] = 'https://example.org/expected/uri';
         $_SERVER['REQUEST_METHOD'] = Request::METHOD_GET;
 
-        Router::configure(static function (Routes $routes, Handlers $handlers): void {
+        $router = new Router(static function (Routes $routes, Handlers $handlers): void {
             $routes->get('expected/uri', FakeControllerWithUnhandledException::class);
 
             $handlers->handle(UnhandledException::class, static function (): string {
@@ -118,6 +122,7 @@ final class ErrorHandlingTest extends HeaderTestCase
                 return 'Handled!';
             });
         });
+        $router->run();
 
         $this->expectOutputString('Handled!');
         self::assertSame([
@@ -134,12 +139,13 @@ final class ErrorHandlingTest extends HeaderTestCase
         $_SERVER['REQUEST_URI'] = 'https://example.org/expected/uri';
         $_SERVER['REQUEST_METHOD'] = Request::METHOD_GET;
 
-        Router::configure(static function (Handlers $handlers): void {
+        $router = new Router(static function (Handlers $handlers): void {
             $handlers->handle(NotFound404Exception::class, static function (): string {
                 \Gacela\Router\header('HTTP/1.1 418 I\'m a teapot');
                 return 'Handled!';
             });
         });
+        $router->run();
 
         $this->expectOutputString('Handled!');
         self::assertSame([
@@ -156,7 +162,7 @@ final class ErrorHandlingTest extends HeaderTestCase
         $_SERVER['REQUEST_URI'] = 'https://example.org/expected/uri';
         $_SERVER['REQUEST_METHOD'] = Request::METHOD_GET;
 
-        Router::configure(static function (Handlers $handlers, Routes $routes): void {
+        $router = new Router(static function (Handlers $handlers, Routes $routes): void {
             $routes->get('expected/uri', FakeControllerWithUnhandledException::class);
 
             $handlers->handle(Exception::class, static function (): string {
@@ -164,6 +170,7 @@ final class ErrorHandlingTest extends HeaderTestCase
                 return 'Handled!';
             });
         });
+        $router->run();
 
         $this->expectOutputString('Handled!');
         self::assertSame([
@@ -180,7 +187,7 @@ final class ErrorHandlingTest extends HeaderTestCase
         $_SERVER['REQUEST_URI'] = 'https://example.org/expected/uri';
         $_SERVER['REQUEST_METHOD'] = Request::METHOD_GET;
 
-        Router::configure(static function (Handlers $handlers, Routes $routes): void {
+        $router = new Router(static function (Handlers $handlers, Routes $routes): void {
             $routes->get('expected/uri', FakeControllerWithUnhandledException::class);
 
             $handlers->handle(UnhandledException::class, new class() {
@@ -191,6 +198,7 @@ final class ErrorHandlingTest extends HeaderTestCase
                 }
             });
         });
+        $router->run();
 
         $this->expectOutputString('Handled!');
         self::assertSame([
@@ -213,7 +221,7 @@ final class ErrorHandlingTest extends HeaderTestCase
         $_SERVER['REQUEST_URI'] = 'https://example.org/expected/uri';
         $_SERVER['REQUEST_METHOD'] = Request::METHOD_GET;
 
-        Router::configure(static function (Handlers $handlers, Routes $routes) use ($given): void {
+        $router = new Router(static function (Handlers $handlers, Routes $routes) use ($given): void {
             $routes->get('expected/uri', static fn () => $given);
 
             $handlers->handle(
@@ -221,6 +229,7 @@ final class ErrorHandlingTest extends HeaderTestCase
                 static fn (UnsupportedResponseTypeException $exception): string => $exception->getMessage(),
             );
         });
+        $router->run();
 
         $this->expectOutputString("Unsupported response type '{$type}'. Must be a string or implement Stringable interface.");
     }

--- a/tests/Feature/Router/RouterBindingTest.php
+++ b/tests/Feature/Router/RouterBindingTest.php
@@ -23,10 +23,11 @@ final class RouterBindingTest extends TestCase
 
         $this->expectOutputString('default-Expected!');
 
-        Router::configure(static function (Bindings $binding, Routes $routes): void {
+        $router = new Router(static function (Bindings $binding, Routes $routes): void {
             $routes->get('expected/uri', FakeControllerWithDependencies::class);
             $binding->bind(NameInterface::class, new Name('Expected!'));
         });
+        $router->run();
     }
 
     public function test_inject_controller_with_request_dependency(): void
@@ -37,8 +38,9 @@ final class RouterBindingTest extends TestCase
 
         $this->expectOutputString('Katarn');
 
-        Router::configure(static function (Routes $routes): void {
+        $router = new Router(static function (Routes $routes): void {
             $routes->get('expected', FakeControllerWithRequest::class);
         });
+        $router->run();
     }
 }

--- a/tests/Feature/Router/RouterMatchTest.php
+++ b/tests/Feature/Router/RouterMatchTest.php
@@ -21,9 +21,10 @@ final class RouterMatchTest extends TestCase
 
         $this->expectOutputString('Expected!');
 
-        Router::configure(static function (Routes $routes): void {
+        $router = new Router(static function (Routes $routes): void {
             $routes->get('expected/uri', FakeController::class, 'basicAction');
         });
+        $router->run();
     }
 
     public function test_respond_only_the_first_match(): void
@@ -33,10 +34,11 @@ final class RouterMatchTest extends TestCase
 
         $this->expectOutputString('Expected!');
 
-        Router::configure(static function (Routes $routes): void {
+        $router = new Router(static function (Routes $routes): void {
             $routes->get('expected/uri', FakeController::class, 'basicAction');
             $routes->get('expected/{param}', FakeController::class, 'stringParamAction');
         });
+        $router->run();
     }
 
     public function test_optional_argument(): void
@@ -46,9 +48,10 @@ final class RouterMatchTest extends TestCase
 
         $this->expectOutputString('Expected!');
 
-        Router::configure(static function (Routes $routes): void {
+        $router = new Router(static function (Routes $routes): void {
             $routes->get('optional/{param?}', FakeController::class, 'basicAction');
         });
+        $router->run();
     }
 
     public function test_multiple_optional_argument(): void
@@ -58,18 +61,20 @@ final class RouterMatchTest extends TestCase
 
         $this->expectOutputString('Expected!');
 
-        Router::configure(static function (Routes $routes): void {
+        $router = new Router(static function (Routes $routes): void {
             $routes->get('optional/{param1?}/{param2?}', FakeController::class, 'basicAction');
         });
+        $router->run();
     }
 
     public function test_thrown_exception_when_method_does_not_exist(): void
     {
         $this->expectException(UnsupportedHttpMethodException::class);
 
-        Router::configure(static function (Routes $routes): void {
+        $router = new Router(static function (Routes $routes): void {
             $routes->invalidName('', FakeController::class);
         });
+        $router->run();
     }
 
     /**
@@ -82,9 +87,10 @@ final class RouterMatchTest extends TestCase
 
         $this->expectOutputString('Expected!');
 
-        Router::configure(static function (Routes $routes): void {
+        $router = new Router(static function (Routes $routes): void {
             $routes->any('expected/uri', FakeController::class, 'basicAction');
         });
+        $router->run();
     }
 
     public function anyHttpMethodProvider(): Generator
@@ -110,9 +116,10 @@ final class RouterMatchTest extends TestCase
 
         $this->expectOutputString('Expected!');
 
-        Router::configure(static function (Routes $routes) use ($givenMethods): void {
+        $router = new Router(static function (Routes $routes) use ($givenMethods): void {
             $routes->match($givenMethods, 'expected/uri', FakeController::class, 'basicAction');
         });
+        $router->run();
     }
 
     public function matchesMethodsProvider(): Generator

--- a/tests/Feature/Router/RouterParamTest.php
+++ b/tests/Feature/Router/RouterParamTest.php
@@ -24,9 +24,10 @@ final class RouterParamTest extends TestCase
 
         $this->expectOutputString("The params are '{$params[0]}', '{$params[1]}' and '{$params[2]}'!");
 
-        Router::configure(static function (Routes $routes): void {
+        $router = new Router(static function (Routes $routes): void {
             $routes->get('{firstParam}/{secondParam}/{thirdParam}', FakeController::class, 'manyParamsAction');
         });
+        $router->run();
     }
 
     public function test_pass_associated_params_by_name_to_the_action(): void
@@ -38,9 +39,10 @@ final class RouterParamTest extends TestCase
 
         $this->expectOutputString("The params are '{$params[1]}', '{$params[0]}' and '{$params[2]}'!");
 
-        Router::configure(static function (Routes $routes): void {
+        $router = new Router(static function (Routes $routes): void {
             $routes->get('{secondParam}/{firstParam}/{thirdParam}', FakeController::class, 'manyParamsAction');
         });
+        $router->run();
     }
 
     /**
@@ -53,15 +55,16 @@ final class RouterParamTest extends TestCase
 
         $this->expectOutputString("The 'string' param is '{$string}'!");
 
-        Router::configure(static function (Routes $routes): void {
+        $router = new Router(static function (Routes $routes): void {
             $routes->get('expected/string/is/{param}', FakeController::class, 'stringParamAction');
         });
+        $router->run();
     }
 
     public function stringProvider(): Generator
     {
         for ($try = 0; $try < self::PROVIDER_TRIES; ++$try) {
-            $randomString = (string)'word-' . mt_rand();
+            $randomString = 'word-' . mt_rand();
             yield $randomString => ['string' => $randomString];
         }
     }
@@ -76,9 +79,10 @@ final class RouterParamTest extends TestCase
 
         $this->expectOutputString("The 'int' param is '{$int}'!");
 
-        Router::configure(static function (Routes $routes): void {
+        $router = new Router(static function (Routes $routes): void {
             $routes->get('expected/integer/is/{param}', FakeController::class, 'intParamAction');
         });
+        $router->run();
     }
 
     public function intProvider(): Generator
@@ -99,9 +103,10 @@ final class RouterParamTest extends TestCase
 
         $this->expectOutputString("The 'float' param is '{$float}'!");
 
-        Router::configure(static function (Routes $routes): void {
+        $router = new Router(static function (Routes $routes): void {
             $routes->get('expected/float/is/{param}', FakeController::class, 'floatParamAction');
         });
+        $router->run();
     }
 
     public function floatProvider(): Generator
@@ -122,9 +127,10 @@ final class RouterParamTest extends TestCase
 
         $this->expectOutputString("The 'bool' param is '{$expected}'!");
 
-        Router::configure(static function (Routes $routes): void {
+        $router = new Router(static function (Routes $routes): void {
             $routes->get('expected/bool/is/{param}', FakeController::class, 'boolParamAction');
         });
+        $router->run();
     }
 
     public function boolProvider(): iterable

--- a/tests/Feature/Router/RouterRedirectTest.php
+++ b/tests/Feature/Router/RouterRedirectTest.php
@@ -19,9 +19,10 @@ final class RouterRedirectTest extends HeaderTestCase
         $_SERVER['REQUEST_URI'] = 'https://example.org/optional/uri';
         $_SERVER['REQUEST_METHOD'] = Request::METHOD_GET;
 
-        Router::configure(static function (Routes $routes) use ($destination): void {
+        $router = new Router(static function (Routes $routes) use ($destination): void {
             $routes->redirect('optional/uri', $destination);
         });
+        $router->run();
 
         self::assertSame([
             [
@@ -40,9 +41,10 @@ final class RouterRedirectTest extends HeaderTestCase
         $_SERVER['REQUEST_URI'] = 'https://example.org/optional/uri';
         $_SERVER['REQUEST_METHOD'] = Request::METHOD_GET;
 
-        Router::configure(static function (Routes $routes) use ($destination, $statusCode): void {
+        $router = new Router(static function (Routes $routes) use ($destination, $statusCode): void {
             $routes->redirect('optional/uri', $destination, $statusCode);
         });
+        $router->run();
 
         self::assertSame([
             [
@@ -61,11 +63,12 @@ final class RouterRedirectTest extends HeaderTestCase
         $_SERVER['REQUEST_URI'] = 'https://example.org/optional/uri';
         $_SERVER['REQUEST_METHOD'] = $method;
 
-        Router::configure(
+        $router = new Router(
             static function (Routes $routes) use ($destination, $statusCode, $method): void {
                 $routes->redirect('optional/uri', $destination, $statusCode, $method);
             },
         );
+        $router->run();
 
         self::assertSame([
             [

--- a/tests/Feature/Router/RouterResponseTest.php
+++ b/tests/Feature/Router/RouterResponseTest.php
@@ -18,9 +18,10 @@ final class RouterResponseTest extends HeaderTestCase
         $_SERVER['REQUEST_URI'] = 'https://example.org/uri';
         $_SERVER['REQUEST_METHOD'] = Request::METHOD_GET;
 
-        Router::configure(static function (Routes $routes): void {
+        $router = new Router(static function (Routes $routes): void {
             $routes->get('uri', static fn () => new Response('body'));
         });
+        $router->run();
 
         $this->expectOutputString('body');
 
@@ -32,11 +33,12 @@ final class RouterResponseTest extends HeaderTestCase
         $_SERVER['REQUEST_URI'] = 'https://example.org/uri';
         $_SERVER['REQUEST_METHOD'] = Request::METHOD_GET;
 
-        Router::configure(static function (Routes $routes): void {
+        $router = new Router(static function (Routes $routes): void {
             $routes->get('uri', static fn () => new JsonResponse([
                 'key' => 'value',
             ]));
         });
+        $router->run();
 
         $this->expectOutputString('{"key":"value"}');
 
@@ -54,12 +56,13 @@ final class RouterResponseTest extends HeaderTestCase
         $_SERVER['REQUEST_URI'] = 'https://example.org/uri';
         $_SERVER['REQUEST_METHOD'] = Request::METHOD_GET;
 
-        Router::configure(static function (Routes $routes): void {
+        $router = new Router(static function (Routes $routes): void {
             $routes->get('uri', static fn () => new Response('{"key":"value"}', [
                 'Access-Control-Allow-Origin: *',
                 'Content-Type: application/json',
             ]));
         });
+        $router->run();
 
         $this->expectOutputString('{"key":"value"}');
 
@@ -82,12 +85,13 @@ final class RouterResponseTest extends HeaderTestCase
         $_SERVER['REQUEST_URI'] = 'https://example.org/uri';
         $_SERVER['REQUEST_METHOD'] = Request::METHOD_GET;
 
-        Router::configure(static function (Routes $routes): void {
+        $router = new Router(static function (Routes $routes): void {
             $routes->get('uri', static fn () => new JsonResponse(['key' => 'value'], [
                 'Access-Control-Allow-Origin: *',
                 'Content-Type: application/json',
             ]));
         });
+        $router->run();
 
         $this->expectOutputString('{"key":"value"}');
 

--- a/tests/Feature/Router/RouterRunTest.php
+++ b/tests/Feature/Router/RouterRunTest.php
@@ -17,13 +17,13 @@ final class RouterRunTest extends HeaderTestCase
         $_SERVER['REQUEST_URI'] = 'https://example.org/uri-2';
         $_SERVER['REQUEST_METHOD'] = Request::METHOD_GET;
 
-        $router = Router::create();
+        $router = new Router();
 
-        $router->addRoutes(static function (Routes $routes): void {
+        $router->configure(static function (Routes $routes): void {
             $routes->get('uri-1', static fn () => new Response('first body'));
         });
 
-        $router->addRoutes(static function (Routes $routes): void {
+        $router->configure(static function (Routes $routes): void {
             $routes->get('uri-2', static fn () => new Response('second body'));
         });
 
@@ -39,13 +39,13 @@ final class RouterRunTest extends HeaderTestCase
         $_SERVER['REQUEST_URI'] = 'https://example.org/uri';
         $_SERVER['REQUEST_METHOD'] = Request::METHOD_GET;
 
-        $router = Router::create();
+        $router = new Router();
 
-        $router->addRoutes(static function (Routes $routes): void {
+        $router->configure(static function (Routes $routes): void {
             $routes->get('uri', static fn () => new Response('first body'));
         });
 
-        $router->addRoutes(static function (Routes $routes): void {
+        $router->configure(static function (Routes $routes): void {
             $routes->get('uri', static fn () => new Response('second body'));
         });
 


### PR DESCRIPTION
## 📚 Description

I think that since the Router became instantiable and it was possible to be configured multiple times, our use of the Router API became somewhat more complex. On the one hand, you could create, configure, and execute the Router statically only using `Router::configure()`, and on the other hand, you could create an instance, configure, and execute it by consecutively calling `Router::create()`, `$router->addRoutes()`, and `$router->run()`.

All of this seems to me to add an extra layer of complexity that could be resolved simply by offering a new non-static method of operation. By doing less for the user and following the KISS principle, the fewer public methods we expose, the simpler it will be for developers to use our API. Therefore, it would be easier to use, although this would force anyone who wants to use the "old static method" to instantiate a router, configure it, and execute it.

In addition, the method for configuring the router instance is called `addRoutes()`, a name that I don't think is entirely appropriate, since it not only serves to add Routes but also Handlers and Dependencies, which I believe makes it even more difficult to use.

This PR is just a proposal for how I think everything could be simplified. Feel free to open up a debate, propose alternatives, make changes...
