### PR TITLE
Add Infection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: 8.0
-          coverage: none
+          coverage: xdebug
           tools: composer
 
       - name: Get composer cache directory

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,3 +115,32 @@ jobs:
 
       - name: Run unit tests
         run: vendor/bin/phpunit
+
+  mutation-tests:
+    name: "Mutation Tests"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.0
+          coverage: none
+          tools: composer
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache dependencies
+        uses: actions/cache@v3.3.1
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Install dependencies
+        run: composer install --no-interaction --no-ansi --no-progress
+
+      - name: Run mutation tests
+        run: ./vendor/bin/infection  --show-mutations --threads=$(nproc)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,4 +143,4 @@ jobs:
         run: composer install --no-interaction --no-ansi --no-progress
 
       - name: Run mutation tests
-        run: ./vendor/bin/infection  --show-mutations --threads=$(nproc)
+        run: ./vendor/bin/infection  --show-mutations --threads=$(nproc) --min-msi=100 --min-covered-msi=100

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ vendor/
 
 *.cache
 composer.lock
+mutation-report.html

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ A minimalistic HTTP router, ideal for your proof-of-concept projects and decoupl
   <a href="https://shepherd.dev/github/gacela-project/router">
     <img src="https://shepherd.dev/github/gacela-project/router/coverage.svg" alt="Psalm Type-coverage Status">
   </a>
+  <a href="https://dashboard.stryker-mutator.io/reports/github.com/gacela-project/router/main">
+    <img src="https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2Fgacela-project%2Frouter%2Fmain" alt="Mutation testing badge">
+  </a>
   <a href="https://github.com/gacela-project/router/blob/master/LICENSE">
     <img src="https://img.shields.io/badge/License-MIT-green.svg" alt="MIT Software License">
   </a>

--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,9 @@
     "require-dev": {
         "ext-mbstring": "*",
         "friendsofphp/php-cs-fixer": "^3.16",
-        "phpunit/phpunit": "^9.6",
+        "infection/infection": "^0.26.16",
         "phpstan/phpstan": "^1.10",
+        "phpunit/phpunit": "^9.6",
         "psalm/plugin-phpunit": "^0.18",
         "symfony/var-dumper": "^5.4",
         "vimeo/psalm": "^5.9"
@@ -21,7 +22,10 @@
         },
         "optimize-autoloader": true,
         "preferred-install": "dist",
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "infection/extension-installer": true
+        }
     },
     "autoload": {
         "psr-4": {
@@ -38,7 +42,8 @@
         "ctal": [
             "@static-clear-cache",
             "@csfix",
-            "@test-all"
+            "@test-all",
+            "@infection"
         ],
         "test-all": [
             "@quality",
@@ -61,6 +66,7 @@
         "psalm": "XDEBUG_MODE=off ./vendor/bin/psalm",
         "phpstan": "XDEBUG_MODE=off ./vendor/bin/phpstan analyze",
         "csfix": "XDEBUG_MODE=off ./vendor/bin/php-cs-fixer fix",
-        "csrun": "XDEBUG_MODE=off ./vendor/bin/php-cs-fixer fix --dry-run"
+        "csrun": "XDEBUG_MODE=off ./vendor/bin/php-cs-fixer fix --dry-run",
+        "infection": "XDEBUG_MODE=coverage ./vendor/bin/infection  --show-mutations --threads=$(nproc)"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -67,6 +67,6 @@
         "phpstan": "XDEBUG_MODE=off ./vendor/bin/phpstan analyze",
         "csfix": "XDEBUG_MODE=off ./vendor/bin/php-cs-fixer fix",
         "csrun": "XDEBUG_MODE=off ./vendor/bin/php-cs-fixer fix --dry-run",
-        "infection": "XDEBUG_MODE=coverage ./vendor/bin/infection  --show-mutations --threads=$(nproc) --min-msi=100 --min-covered-msi=100"
+        "infection": "XDEBUG_MODE=coverage ./vendor/bin/infection  --show-mutations --threads=8 --min-msi=100 --min-covered-msi=100"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -67,6 +67,6 @@
         "phpstan": "XDEBUG_MODE=off ./vendor/bin/phpstan analyze",
         "csfix": "XDEBUG_MODE=off ./vendor/bin/php-cs-fixer fix",
         "csrun": "XDEBUG_MODE=off ./vendor/bin/php-cs-fixer fix --dry-run",
-        "infection": "XDEBUG_MODE=coverage ./vendor/bin/infection  --show-mutations --threads=$(nproc)"
+        "infection": "XDEBUG_MODE=coverage ./vendor/bin/infection  --show-mutations --threads=$(nproc) --min-msi=100 --min-covered-msi=100"
     }
 }

--- a/infection.json5
+++ b/infection.json5
@@ -1,0 +1,11 @@
+{
+    "$schema": "vendor/infection/infection/resources/schema.json",
+    "source": {
+        "directories": [
+            "src"
+        ]
+    },
+    "mutators": {
+        "@default": true
+    }
+}

--- a/infection.json5
+++ b/infection.json5
@@ -1,7 +1,10 @@
 {
     $schema: 'vendor/infection/infection/resources/schema.json',
     logs: {
-        html: 'mutation-report.html'
+        html: 'mutation-report.html',
+        "stryker": {
+            "badge": "main"
+        }
     },
     timeout: 3,
     source: {

--- a/infection.json5
+++ b/infection.json5
@@ -1,11 +1,15 @@
 {
-    "$schema": "vendor/infection/infection/resources/schema.json",
-    "source": {
-        "directories": [
-            "src"
+    $schema: 'vendor/infection/infection/resources/schema.json',
+    logs: {
+        html: 'mutation-report.html'
+    },
+    timeout: 3,
+    source: {
+        directories: [
+            'src'
         ]
     },
-    "mutators": {
-        "@default": true
+    mutators: {
+        '@default': true
     }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,6 +4,3 @@ parameters:
         - %currentWorkingDirectory%/src/
     checkGenericClassInNonGenericObjectType: false
     checkMissingIterableValueType: false
-
-    ignoreErrors:
-        - '#Match expression does not handle remaining value: string#'

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit bootstrap="vendor/autoload.php"
-         backupGlobals="false"
+         backupGlobals="true"
          backupStaticAttributes="false"
          colors="true"
          convertErrorsToExceptions="true"

--- a/src/Router/Entities/Request.php
+++ b/src/Router/Entities/Request.php
@@ -62,7 +62,6 @@ final class Request
     {
         return $this->request[$key]
             ?? $this->query[$key]
-            ?? $this->server[$key]
             ?? null;
     }
 }

--- a/src/Router/Entities/Request.php
+++ b/src/Router/Entities/Request.php
@@ -42,8 +42,10 @@ final class Request
 
     public function isMethod(string $method): bool
     {
-        /** @psalm-suppress PossiblyUndefinedArrayOffset */
-        return (string)$this->server['REQUEST_METHOD'] === $method;
+        /** @var string $requestMethod */
+        $requestMethod = $this->server['REQUEST_METHOD'];
+
+        return $requestMethod === $method;
     }
 
     public function path(): string

--- a/src/Router/Entities/Request.php
+++ b/src/Router/Entities/Request.php
@@ -50,11 +50,12 @@ final class Request
 
     public function path(): string
     {
-        /** @psalm-suppress PossiblyUndefinedArrayOffset */
-        return (string)parse_url(
-            (string)$this->server['REQUEST_URI'],
-            PHP_URL_PATH,
-        );
+        /** @var string $requestUri */
+        $requestUri = $this->server['REQUEST_URI'];
+        /** @var string $parsedUrl */
+        $parsedUrl = parse_url($requestUri, PHP_URL_PATH);
+
+        return $parsedUrl;
     }
 
     public function get(string $key): mixed

--- a/src/Router/Entities/Route.php
+++ b/src/Router/Entities/Route.php
@@ -85,7 +85,7 @@ final class Route
         return $this->methodMatches() && $this->pathMatches();
     }
 
-    public function methodMatches(): bool
+    private function methodMatches(): bool
     {
         return Request::fromGlobals()->isMethod($this->method);
     }

--- a/src/Router/Entities/Route.php
+++ b/src/Router/Entities/Route.php
@@ -6,7 +6,6 @@ namespace Gacela\Router\Entities;
 
 use Gacela\Container\Container;
 use Gacela\Router\Bindings;
-
 use Gacela\Router\Exceptions\UnsupportedResponseTypeException;
 use Stringable;
 

--- a/src/Router/Entities/Route.php
+++ b/src/Router/Entities/Route.php
@@ -54,11 +54,6 @@ final class Route
         return $this->path;
     }
 
-    public function method(): string
-    {
-        return $this->method;
-    }
-
     /**
      * @return object|class-string
      */

--- a/src/Router/Entities/Route.php
+++ b/src/Router/Entities/Route.php
@@ -31,7 +31,7 @@ final class Route
      */
     public function run(Bindings $bindings): string|Stringable
     {
-        $params = (new RouteParams($this))->asArray();
+        $params = (new RouteParams($this))->getAll();
 
         if (!is_object($this->controller)) {
             $creator = new Container($bindings->getAllBindings());

--- a/src/Router/Entities/RouteParams.php
+++ b/src/Router/Entities/RouteParams.php
@@ -48,7 +48,7 @@ final class RouteParams
             ->getParameters();
 
         foreach ($actionParams as $actionParam) {
-            /**@var string|null $paramType */
+            /** @var string|null $paramType */
             $paramType = $actionParam->getType()?->__toString();
 
             $paramName = $actionParam->getName();

--- a/src/Router/Entities/RouteParams.php
+++ b/src/Router/Entities/RouteParams.php
@@ -4,23 +4,24 @@ declare(strict_types=1);
 
 namespace Gacela\Router\Entities;
 
+use Gacela\Router\Exceptions\UnsupportedParamTypeException;
 use ReflectionClass;
 
 use function count;
 
 final class RouteParams
 {
-    private array $asArray;
+    private array $params;
 
     public function __construct(
         private Route $route,
     ) {
-        $this->asArray = $this->getParams();
+        $this->params = $this->getParams();
     }
 
-    public function asArray(): array
+    public function getAll(): array
     {
-        return $this->asArray;
+        return $this->params;
     }
 
     /**
@@ -58,7 +59,8 @@ final class RouteParams
                 'int' => (int)$pathParams[$paramName],
                 'float' => (float)$pathParams[$paramName],
                 'bool' => (bool)json_decode($pathParams[$paramName]),
-                null => null,
+                null => throw UnsupportedParamTypeException::nonTyped(),
+                default => throw UnsupportedParamTypeException::fromType($paramType),
             };
 
             $params[$paramName] = $value;

--- a/src/Router/Entities/RouteParams.php
+++ b/src/Router/Entities/RouteParams.php
@@ -24,9 +24,6 @@ final class RouteParams
         return $this->params;
     }
 
-    /**
-     * @psalm-suppress MixedAssignment,PossiblyNullReference
-     */
     private function getParams(): array
     {
         $params = [];

--- a/src/Router/Entities/RouteParams.php
+++ b/src/Router/Entities/RouteParams.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Gacela\Router\Entities;
 
 use ReflectionClass;
-use ReflectionNamedType;
 
 use function count;
 
@@ -49,12 +48,8 @@ final class RouteParams
             ->getParameters();
 
         foreach ($actionParams as $actionParam) {
-            /** @var string|null $paramType */
-            $paramType = null;
-
-            if ($actionParam->getType() && is_a($actionParam->getType(), ReflectionNamedType::class)) {
-                $paramType = $actionParam->getType()->getName();
-            }
+            /**@var string|null $paramType */
+            $paramType = $actionParam->getType()?->__toString();
 
             $paramName = $actionParam->getName();
 

--- a/src/Router/Entities/RouteParams.php
+++ b/src/Router/Entities/RouteParams.php
@@ -59,10 +59,10 @@ final class RouteParams
             $paramName = $actionParam->getName();
 
             $value = match ($paramType) {
-                'string' => $pathParams[$paramName] ?? '',
-                'int' => (int)($pathParams[$paramName] ?? 0),
-                'float' => (float)($pathParams[$paramName] ?? 0.0),
-                'bool' => (bool)json_decode($pathParams[$paramName] ?? '0'),
+                'string' => $pathParams[$paramName],
+                'int' => (int)$pathParams[$paramName],
+                'float' => (float)$pathParams[$paramName],
+                'bool' => (bool)json_decode($pathParams[$paramName]),
                 null => null,
             };
 

--- a/src/Router/Exceptions/NonCallableHandlerException.php
+++ b/src/Router/Exceptions/NonCallableHandlerException.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Router\Exceptions;
+
+use RuntimeException;
+
+class NonCallableHandlerException extends RuntimeException
+{
+    /**
+     * @param class-string $class
+     *
+     * @return self
+     */
+    public static function fromException(string $class): self
+    {
+        return new self("Handler assigned to '{$class}' exception cannot be called.");
+    }
+}

--- a/src/Router/Exceptions/UnsupportedParamTypeException.php
+++ b/src/Router/Exceptions/UnsupportedParamTypeException.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Router\Exceptions;
+
+use RuntimeException;
+
+final class UnsupportedParamTypeException extends RuntimeException
+{
+    public static function fromType(string $type): self
+    {
+        return new self("Unsupported param type '{$type}'. Must be a scalar.");
+    }
+
+    public static function nonTyped(): self
+    {
+        return new self('Unsupported non-typed param. Must be a scalar.');
+    }
+}

--- a/src/Router/Exceptions/UnsupportedRouterConfigureCallableParamException.php
+++ b/src/Router/Exceptions/UnsupportedRouterConfigureCallableParamException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Router\Exceptions;
+
+use ReflectionParameter;
+use RuntimeException;
+
+final class UnsupportedRouterConfigureCallableParamException extends RuntimeException
+{
+    public static function fromName(ReflectionParameter $name): self
+    {
+        return new self("'{$name->getName()}' parameter in configuration Closure for Router must be from types Routes, Bindings or Handlers.");
+    }
+}

--- a/src/Router/Router.php
+++ b/src/Router/Router.php
@@ -8,6 +8,7 @@ use Closure;
 use Exception;
 use Gacela\Container\Container;
 use Gacela\Router\Entities\Route;
+use Gacela\Router\Exceptions\NonCallableHandlerException;
 use Gacela\Router\Exceptions\NotFound404Exception;
 use Gacela\Router\Exceptions\UnsupportedRouterConfigureCallableParamException;
 use ReflectionFunction;
@@ -83,7 +84,7 @@ final class Router
             return $instance($exception);
         }
 
-        return '';
+        throw NonCallableHandlerException::fromException($exception::class);
     }
 
     /**

--- a/src/Router/Router.php
+++ b/src/Router/Router.php
@@ -9,6 +9,7 @@ use Exception;
 use Gacela\Container\Container;
 use Gacela\Router\Entities\Route;
 use Gacela\Router\Exceptions\NotFound404Exception;
+use Gacela\Router\Exceptions\UnsupportedRouterConfigureCallableParamException;
 use ReflectionFunction;
 
 use function get_class;
@@ -39,7 +40,7 @@ final class Router
             Routes::class => $this->routes,
             Bindings::class => $this->bindings,
             Handlers::class => $this->handlers,
-            default => null,
+            default => throw UnsupportedRouterConfigureCallableParamException::fromName($param),
         }, (new ReflectionFunction($fn))->getParameters());
 
         $fn(...$params);
@@ -75,7 +76,7 @@ final class Router
             return $handler($exception);
         }
 
-        /** @var mixed $instance */
+        /** @psalm-suppress MixedAssignment */
         $instance = Container::create($handler);
 
         if (is_callable($instance)) {

--- a/src/Router/Routes.php
+++ b/src/Router/Routes.php
@@ -87,7 +87,7 @@ final class Routes
             $methods = [$methods];
         }
 
-        $methods = array_map(static fn ($method) => strtoupper(trim($method)), $methods);
+        $methods = array_map(static fn ($method) => strtoupper($method), $methods);
 
         foreach ($methods as $method) {
             if (!in_array($method, Request::ALL_METHODS, true)) {

--- a/tests/Feature/Router/ErrorHandlingTest.php
+++ b/tests/Feature/Router/ErrorHandlingTest.php
@@ -285,4 +285,19 @@ final class ErrorHandlingTest extends HeaderTestCase
 
         new Router(static function ($unrecognised): void {});
     }
+
+    public function test_configure_non_callable_handler(): void
+    {
+        $_SERVER['REQUEST_URI'] = 'https://example.org/expected/uri';
+        $_SERVER['REQUEST_METHOD'] = Request::METHOD_GET;
+
+        $this->expectExceptionMessage('Handler assigned to \'GacelaTest\Feature\Router\Fixtures\UnhandledException\' exception cannot be called.');
+
+        $router = new Router(static function (Handlers $handlers, Routes $routes): void {
+            $routes->get('expected/uri', FakeControllerWithUnhandledException::class);
+
+            $handlers->handle(UnhandledException::class, 'non-callable');
+        });
+        $router->run();
+    }
 }

--- a/tests/Feature/Router/ErrorHandlingTest.php
+++ b/tests/Feature/Router/ErrorHandlingTest.php
@@ -278,4 +278,11 @@ final class ErrorHandlingTest extends HeaderTestCase
 
         $this->expectOutputString("Unsupported param type 'array'. Must be a scalar.");
     }
+
+    public function test_configure_throws_unsupported_closure_param(): void
+    {
+        $this->expectExceptionMessage("'unrecognised' parameter in configuration Closure for Router must be from types Routes, Bindings or Handlers.");
+
+        new Router(static function ($unrecognised): void {});
+    }
 }

--- a/tests/Feature/Router/ErrorHandlingTest.php
+++ b/tests/Feature/Router/ErrorHandlingTest.php
@@ -245,7 +245,7 @@ final class ErrorHandlingTest extends HeaderTestCase
 
     public function test_throws_exception_when_param_has_no_type(): void
     {
-        $_SERVER['REQUEST_URI'] = "https://example.org/expected/param/is/any";
+        $_SERVER['REQUEST_URI'] = 'https://example.org/expected/param/is/any';
         $_SERVER['REQUEST_METHOD'] = Request::METHOD_GET;
 
         $router = new Router(static function (Routes $routes, Handlers $handlers): void {

--- a/tests/Feature/Router/ErrorHandlingTest.php
+++ b/tests/Feature/Router/ErrorHandlingTest.php
@@ -141,14 +141,14 @@ final class ErrorHandlingTest extends HeaderTestCase
         $_SERVER['REQUEST_METHOD'] = Request::METHOD_GET;
 
         $router = new Router(static function (Handlers $handlers): void {
-            $handlers->handle(NotFound404Exception::class, static function (): string {
+            $handlers->handle(NotFound404Exception::class, static function (NotFound404Exception $exception): string {
                 \Gacela\Router\header('HTTP/1.1 418 I\'m a teapot');
-                return 'Handled!';
+                return "'{$exception->getMessage()}' Handled!";
             });
         });
         $router->run();
 
-        $this->expectOutputString('Handled!');
+        $this->expectOutputString("'Error 404 - Not Found' Handled!");
         self::assertSame([
             [
                 'header' => 'HTTP/1.1 418 I\'m a teapot',

--- a/tests/Feature/Router/Fixtures/FakeController.php
+++ b/tests/Feature/Router/Fixtures/FakeController.php
@@ -40,4 +40,17 @@ final class FakeController
     {
         return "The params are '{$firstParam}', '{$secondParam}' and '{$thirdParam}'!";
     }
+
+    /**
+     * @param mixed $param
+     */
+    public function nonTypedParam($param): string
+    {
+        return 'I AM ERROR!';
+    }
+
+    public function nonScalarParam(array $param): string
+    {
+        return 'I AM ERROR!';
+    }
 }

--- a/tests/Feature/Router/RouterParamTest.php
+++ b/tests/Feature/Router/RouterParamTest.php
@@ -8,6 +8,7 @@ use Gacela\Router\Entities\Request;
 use Gacela\Router\Router;
 use Gacela\Router\Routes;
 use GacelaTest\Feature\Router\Fixtures\FakeController;
+use GacelaTest\Feature\Router\Fixtures\FakeControllerWithRequest;
 use Generator;
 use PHPUnit\Framework\TestCase;
 
@@ -139,5 +140,20 @@ final class RouterParamTest extends TestCase
         yield 'false' => ['given' => 'false', 'expected' => 'false'];
         yield '1' => ['given' => '1', 'expected' => 'true'];
         yield '0' => ['given' => '0', 'expected' => 'false'];
+    }
+
+    public function test_priori_post_params_over_get(): void
+    {
+        $_SERVER['REQUEST_URI'] = "https://example.org/expected/uri";
+        $_SERVER['REQUEST_METHOD'] = Request::METHOD_GET;
+        $_GET['name'] = 'Unexpected!';
+        $_POST['name'] = 'Expected!';
+
+        $this->expectOutputString('Expected!');
+
+        $router = new Router(static function (Routes $routes): void {
+            $routes->get('expected/uri', FakeControllerWithRequest::class);
+        });
+        $router->run();
     }
 }

--- a/tests/Feature/Router/RouterParamTest.php
+++ b/tests/Feature/Router/RouterParamTest.php
@@ -144,7 +144,7 @@ final class RouterParamTest extends TestCase
 
     public function test_priori_post_params_over_get(): void
     {
-        $_SERVER['REQUEST_URI'] = "https://example.org/expected/uri";
+        $_SERVER['REQUEST_URI'] = 'https://example.org/expected/uri';
         $_SERVER['REQUEST_METHOD'] = Request::METHOD_GET;
         $_GET['name'] = 'Unexpected!';
         $_POST['name'] = 'Expected!';


### PR DESCRIPTION
## 📚 Description

Out of curiosity, I have installed and configured Infection in the project. It is a library that allows applying the mutation testing methodology in PHP. This methodology makes small modifications to the production code to try to detect whether the test suite detects these changes or not. Each of these small changes should always be detected by one of our tests. If not, the library reports it so that we can act accordingly.

This library thus makes our tests better, helping us achieve 100% coverage and ensuring that we test all edge cases. However, like everything else, being an automated process, it can also produce false positives. Therefore, it is up to our discretion to decide whether to fix or ignore these failures.

I launched the command to take a look and the truth is that we got a pretty good results. However, it still detected that one mutation had no coverage, 14 were not detected by any test, and 8 timed out. Nonetheless, we have some enviable metrics!

![imagen](https://user-images.githubusercontent.com/13595197/235253436-314c15b5-a41e-4305-b60d-976dc8088a2a.png)
![imagen](https://user-images.githubusercontent.com/13595197/235253477-d333faeb-aa86-4963-a192-cc09cab70f4d.png)

I'm creating this draft to work on it, so you can take a look and decide whether to incorporate this methodology (perhaps to apply it to the other Gacela modules) and to check the errors it has detected. We can also add it as a step in the CI pipeline.

## 🔖 Changes

- I have installed Infection as a development dependency.
- I have added Infection as new script in the composer.json file, in such a way that it launches as many threads as cores has the computer where the command is executed.
- I have added this new script as the last step in the composer ctal script.
- I have added a basic configuration for Infection to work for now, and we will have to fine-tune it gradually.

## 🤔 Considerations

Since my computer has 16 cores, the script's execution time is exactly 10 seconds, which is the default timeout amount. Currently, we have 8 timeouts, so on computers with less than 8 cores, the execution time will be between 20 and 80 seconds.

We need to study whether these timeouts are something we can fix (or ignore), so that we ensure they don't potentially add 10 seconds each on slower computers (those with a single core). However, since our test suite is so fast, another option we have is to drastically reduce the timeout amount. Nevertheless, as I mentioned earlier, we need to consider what to do in this situation.
