### PR TITLE
Bug when having similar routes with optional arguments

### DIFF
--- a/tests/Feature/Router/Fixtures/FakeController.php
+++ b/tests/Feature/Router/Fixtures/FakeController.php
@@ -36,7 +36,7 @@ final class FakeController
         return "The '{$type}' param is '{$stringParam}'!";
     }
 
-    public function manyParamsAction(string $firstParam, string $secondParam, string $thirdParam): string
+    public function manyParamsAction(string $firstParam, string $secondParam, string $thirdParam = 'optional'): string
     {
         return "The params are '{$firstParam}', '{$secondParam}' and '{$thirdParam}'!";
     }

--- a/tests/Feature/Router/RouterParamTest.php
+++ b/tests/Feature/Router/RouterParamTest.php
@@ -46,6 +46,22 @@ final class RouterParamTest extends TestCase
         $router->run();
     }
 
+    public function test_pass_associated_params_by_name_with_one_optional_param(): void
+    {
+        $params = ['foo', 'bar'];
+
+        $_SERVER['REQUEST_URI'] = "https://example.org/{$params[0]}/{$params[1]}";
+        $_SERVER['REQUEST_METHOD'] = Request::METHOD_GET;
+
+        $this->expectOutputString("The params are '{$params[1]}', '{$params[0]}' and 'optional'!");
+
+        $router = new Router(static function (Routes $routes): void {
+            $routes->get('{secondParam}/{firstParam}/{thirdParam}', FakeController::class, 'manyParamsAction');
+            $routes->get('{secondParam}/{firstParam}', FakeController::class, 'manyParamsAction');
+        });
+        $router->run();
+    }
+
     /**
      * @dataProvider stringProvider
      */


### PR DESCRIPTION
## 📚 Description

Having `https://example.org/{$params[0]}/{$params[1]}`
I would expect ending up in this route `{secondParam}/{firstParam}`
And that should go `manyParamsAction(string $firstParam, string $secondParam, string $thirdParam = 'optional')`
However, it goes to `{secondParam}/{firstParam}/{thirdParam}` which is configured as:
```php
$router = new Router(static function (Routes $routes): void {
    $routes->get('{secondParam}/{firstParam}/{thirdParam}', FakeController::class, 'manyParamsAction');
    $routes->get('{secondParam}/{firstParam}', FakeController::class, 'manyParamsAction');
});
```

## 🔖 Changes

- Prepared failing test_pass_associated_params_by_name_with_one_optional_param
- TODO: Fix the bug 🐛  
