### PR TITLE
Allow default request get values

### DIFF
--- a/src/Router/Entities/Request.php
+++ b/src/Router/Entities/Request.php
@@ -58,10 +58,10 @@ final class Request
         return $parsedUrl;
     }
 
-    public function get(string $key): mixed
+    public function get(string $key, mixed $default = null): mixed
     {
         return $this->request[$key]
             ?? $this->query[$key]
-            ?? null;
+            ?? $default;
     }
 }

--- a/src/Router/Entities/Request.php
+++ b/src/Router/Entities/Request.php
@@ -60,8 +60,13 @@ final class Request
 
     public function get(string $key, mixed $default = null): mixed
     {
-        return $this->request[$key]
-            ?? $this->query[$key]
-            ?? $default;
+        /** @var mixed $result */
+        $result = $this->request[$key] ?? $this->query[$key] ?? null;
+
+        if ($result !== null) {
+            return $result;
+        }
+
+        return $default;
     }
 }

--- a/tests/Unit/Router/Entities/RequestTest.php
+++ b/tests/Unit/Router/Entities/RequestTest.php
@@ -2,20 +2,29 @@
 
 declare(strict_types=1);
 
-namespace Unit\Router\Entities;
+namespace GacelaTest\Unit\Router\Entities;
 
 use Gacela\Router\Entities\Request;
 use PHPUnit\Framework\TestCase;
 
 final class RequestTest extends TestCase
 {
-    public function test_existing_request_key(): void
+    public function test_existing_request_key_get(): void
     {
-        $_GET['key'] = 'value';
+        $_GET['get_key'] = 'get value';
         $request = Request::fromGlobals();
 
-        self::assertSame('value', $request->get('key'));
-        unset($_GET['key']);
+        self::assertSame('get value', $request->get('get_key'));
+        unset($_GET['get_key']);
+    }
+
+    public function test_existing_request_key_post(): void
+    {
+        $_POST['post_key'] = 'post value';
+        $request = Request::fromGlobals();
+
+        self::assertSame('post value', $request->get('post_key'));
+        unset($_POST['post_key']);
     }
 
     public function test_non_existing_request_key(): void

--- a/tests/Unit/Router/Entities/RequestTest.php
+++ b/tests/Unit/Router/Entities/RequestTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Unit\Router\Entities;
+
+use Gacela\Router\Entities\Request;
+use PHPUnit\Framework\TestCase;
+
+final class RequestTest extends TestCase
+{
+    public function test_existing_request_key(): void
+    {
+        $_GET['key'] = 'value';
+        $request = Request::fromGlobals();
+
+        self::assertSame('value', $request->get('key'));
+        unset($_GET['key']);
+    }
+
+    public function test_non_existing_request_key(): void
+    {
+        $request = Request::fromGlobals();
+
+        self::assertNull($request->get('non-existing-key'));
+    }
+
+    public function test_default_request_get_value(): void
+    {
+        $request = Request::fromGlobals();
+        $actual = $request->get('non-existing-key', 'default-value');
+
+        self::assertSame('default-value', $actual);
+    }
+}


### PR DESCRIPTION
## 🔖 Changes

- Allow optional default value on `get()` from `Request`
  - `Request->get(key, default = null)`
